### PR TITLE
Add country restriction option

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Available mappings:
 - longitude
 - vicinity
 
+Available options:
+
+You can restrict the address lookup to certain countries by defining the `countryRestrictions` option. The option accepts a comma separated list of ISO 3166-1 ALPHA-2 compatible country codes (see: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
+
 Usage:
 
     # ===================================
@@ -142,6 +146,7 @@ Usage:
         address:
             label: Address
             type: addressfinder
+            countryRestrictions: 'us,ch'
             fieldMap:
                 latitude: latitude
                 longitude: longitude

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Available mappings:
 
 Available options:
 
-You can restrict the address lookup to certain countries by defining the `countryRestrictions` option. The option accepts a comma separated list of ISO 3166-1 ALPHA-2 compatible country codes (see: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
+You can restrict the address lookup to certain countries by defining the `countryRestriction` option. The option accepts a comma separated list of ISO 3166-1 ALPHA-2 compatible country codes (see: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
 
 Usage:
 
@@ -146,7 +146,7 @@ Usage:
         address:
             label: Address
             type: addressfinder
-            countryRestrictions: 'us,ch'
+            countryRestriction: 'us,ch'
             fieldMap:
                 latitude: latitude
                 longitude: longitude

--- a/formwidgets/AddressFinder.php
+++ b/formwidgets/AddressFinder.php
@@ -13,6 +13,7 @@ use RainLab\Location\Models\Setting;
  *   address:
  *       label: Address
  *       type: addressfinder
+ *       countryRestrictions: 'us,ch'
  *       fieldMap:
  *           latitude: latitude
  *           longitude: longitude
@@ -30,6 +31,7 @@ class AddressFinder extends FormWidgetBase
     public $defaultAlias = 'addressfinder';
 
     protected $fieldMap;
+    protected $countryRestrictions;
 
     /**
      * {@inheritDoc}
@@ -37,6 +39,7 @@ class AddressFinder extends FormWidgetBase
     public function init()
     {
         $this->fieldMap = $this->getConfig('fieldMap', []);
+        $this->countryRestrictions = $this->getConfig('countryRestrictions', null);
     }
 
     /**
@@ -74,6 +77,11 @@ class AddressFinder extends FormWidgetBase
         }
 
         return Html::attributes($result);
+    }
+
+    public function getCountryRestrictions()
+    {
+        return $this->countryRestrictions;
     }
 
     /**

--- a/formwidgets/AddressFinder.php
+++ b/formwidgets/AddressFinder.php
@@ -13,7 +13,7 @@ use RainLab\Location\Models\Setting;
  *   address:
  *       label: Address
  *       type: addressfinder
- *       countryRestrictions: 'us,ch'
+ *       countryRestriction: 'us,ch'
  *       fieldMap:
  *           latitude: latitude
  *           longitude: longitude
@@ -31,7 +31,7 @@ class AddressFinder extends FormWidgetBase
     public $defaultAlias = 'addressfinder';
 
     protected $fieldMap;
-    protected $countryRestrictions;
+    protected $countryRestriction;
 
     /**
      * {@inheritDoc}
@@ -39,7 +39,7 @@ class AddressFinder extends FormWidgetBase
     public function init()
     {
         $this->fieldMap = $this->getConfig('fieldMap', []);
-        $this->countryRestrictions = $this->getConfig('countryRestrictions', '');
+        $this->countryRestriction = $this->getConfig('countryRestriction', '');
     }
 
     /**
@@ -79,9 +79,9 @@ class AddressFinder extends FormWidgetBase
         return Html::attributes($result);
     }
 
-    public function getCountryRestrictions()
+    public function getCountryRestriction()
     {
-        return $this->countryRestrictions;
+        return $this->countryRestriction;
     }
 
     /**

--- a/formwidgets/AddressFinder.php
+++ b/formwidgets/AddressFinder.php
@@ -39,7 +39,7 @@ class AddressFinder extends FormWidgetBase
     public function init()
     {
         $this->fieldMap = $this->getConfig('fieldMap', []);
-        $this->countryRestrictions = $this->getConfig('countryRestrictions', null);
+        $this->countryRestrictions = $this->getConfig('countryRestrictions', '');
     }
 
     /**

--- a/formwidgets/addressfinder/assets/js/location-autocomplete.js
+++ b/formwidgets/addressfinder/assets/js/location-autocomplete.js
@@ -24,7 +24,7 @@
         type="text"
         class="form-control"
         data-control="location-autocomplete"
-        data-country-restrictions="us,ch"
+        data-country-restriction="us,ch"
         data-input-street="#inputStreet"
         data-input-city="#locationCity"
         data-input-state="#locationState"
@@ -70,9 +70,9 @@
         var autocompleteOptions = {
             types: ['geocode']
         }
-        var countryRestrictions = this.$el.data('countryRestrictions')
-        if (countryRestrictions) {
-            var countryCodes = countryRestrictions.split(',').map(function(code) {
+        var countryRestriction = this.$el.data('countryRestriction')
+        if (countryRestriction) {
+            var countryCodes = countryRestriction.split(',').map(function(code) {
                 return code.trim();
             });
             autocompleteOptions['componentRestrictions'] = {

--- a/formwidgets/addressfinder/assets/js/location-autocomplete.js
+++ b/formwidgets/addressfinder/assets/js/location-autocomplete.js
@@ -1,6 +1,6 @@
 /*
  * Location Autocomplete plugin
- * 
+ *
  * Data attributes:
  * - data-control="location-autocomplete" - enables the plugin on an element
  * - data-input-street="#locationStreet" - input to populate with street
@@ -24,6 +24,7 @@
         type="text"
         class="form-control"
         data-control="location-autocomplete"
+        data-country-restrictions="us,ch"
         data-input-street="#inputStreet"
         data-input-city="#locationCity"
         data-input-state="#locationState"
@@ -36,7 +37,7 @@
     <input type="text" name="state" value="" id="locationState" />
     <input type="text" name="zip" value="" id="locationZip" />
     <input type="text" name="country" value="" id="locationCountry" />
- * 
+ *
  */
 
 
@@ -66,9 +67,19 @@
     }
 
     LocationAutocomplete.prototype.init = function() {
-        this.autocomplete = new map.places.Autocomplete(this.$el.get(0), {
+        var autocompleteOptions = {
             types: ['geocode']
-        })
+        }
+        var countryRestrictions = this.$el.data('countryRestrictions')
+        if (countryRestrictions) {
+            var countryCodes = countryRestrictions.split(',').map(function(code) {
+                return code.trim();
+            });
+            autocompleteOptions['componentRestrictions'] = {
+                'country': countryCodes
+            }
+        }
+        this.autocomplete = new map.places.Autocomplete(this.$el.get(0), autocompleteOptions)
 
         map.event.addListener(this.autocomplete, 'place_changed', $.proxy(this.handlePlaceChanged, this))
 

--- a/formwidgets/addressfinder/partials/_addressfinder.htm
+++ b/formwidgets/addressfinder/partials/_addressfinder.htm
@@ -11,6 +11,7 @@
             class="form-control"
             data-control="location-autocomplete"
             <?= $field->getAttributes() ?>
+            data-country-restrictions="<?= $this->getCountryRestrictions() ?>"
             <?= $this->getFieldMapAttributes() ?>
             />
     </div>

--- a/formwidgets/addressfinder/partials/_addressfinder.htm
+++ b/formwidgets/addressfinder/partials/_addressfinder.htm
@@ -11,7 +11,7 @@
             class="form-control"
             data-control="location-autocomplete"
             <?= $field->getAttributes() ?>
-            data-country-restrictions="<?= $this->getCountryRestrictions() ?>"
+            data-country-restriction="<?= $this->getCountryRestriction() ?>"
             <?= $this->getFieldMapAttributes() ?>
             />
     </div>


### PR DESCRIPTION
This pull request adds new option `countryRestriction` to restrict location lookup to defined countries.
Example: `countryRestriction: 'us,ch'` (Restrict adress lookup to United States of America and Switzerland)